### PR TITLE
Add Formattable Trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,32 @@
 
 [![Build Status](https://travis-ci.org/jarektkaczyk/eloquence.svg?branch=master)](https://travis-ci.org/jarektkaczyk/eloquence)
 
-
-(WIP currently only `Mappable` - inspired by https://github.com/RomainLanz/laravel-attributes-mapper, much more to come soon!)
-
 Useful extensions for the Eloquent ORM.
 
-## Requirements
+:construction: **WIP** currently only `Mappable` (inspired by @RomainLanz) and `Formattable`
+If you want to know more about new extensions you can check our [Roadmap](#roadmap)!
+
+# Table of Contents
+
+* [Team Members](#team-members)
+* [Requirements](#requirements)
+* [Getting Started](#getting-started)
+* [Mappable](#mappable)
+  * [Explicit vs. Implicit mappings](#explicit-vs-implicit-mappings)
+* [Formattable](#formattable)
+* [Roadmap](#roadmap)
+
+# <a name="team-members"></a>Team Members
+
+* Jarek Tkaczyk ([SOFTonSOFA](http://softonsofa.com/)) <jarek@softonsofa.com>
+
+# <a name="requirements"></a>Requirements
 
 * This package requires PHP 5.4+
 
-## Usage
+# <a name="getting-started"></a>Getting Started
 
-### 1. Require the package in your `composer.json`:
+1. Require the package in your `composer.json`:
 
 ```
     "require": {
@@ -24,9 +38,13 @@ Useful extensions for the Eloquent ORM.
 
 ```
 
-### 2. Add trait to the model and define mappings:
+2. Add trait you want to use to the model.
 
-```
+# <a name="mappable"></a>Mappable
+
+Define mappings on the protected `$maps` variable like bellow.
+
+```php
 <?php namespace App;
 
 use Sofa\Eloquence\Mappable; // trait
@@ -49,9 +67,9 @@ class User extends \Eloquent {
     }
 ```
 
-### You can also add mapped attributes to the array representation of your model, just like any accessor:
+You can also add mapped attributes to the array representation of your model, just like any accessor:
 
-```
+```php
 <?php namespace App;
 
 use Sofa\Eloquence\Mappable; // trait
@@ -68,9 +86,9 @@ class User extends \Eloquent {
 }
 ```
 
-### You can get as well as set mapped attributes:
+You can get as well as set mapped attributes:
 
-```
+```php
 $user->profile->first_name; // 'Jarek Tkaczyk'
 $user->first_name = 'John Doe';
 
@@ -83,12 +101,12 @@ $user->push();
 ```
 
 
-## Explicit vs. Implicit mappings
+## <a name="explicit-vs-implicit-mappings"></a>Explicit vs. Implicit mappings
 
 `Mappable` offers 2 ways of defining mappings for your convenience.
 
 Let's compare equivalent mappings:
-```
+```php
 // Assuming User belongsTo Profile
 // and Profile hasOne Picture
 // profiles table: id, first_name, last_name
@@ -111,3 +129,36 @@ protected $maps = [
 ```
 
 As you notice behaviour is just the same. However there is slight difference - explicit mapping offers more flexibility, in that you can define custom key for mapped value (`picture_path`), while with implicit mapping you have to use real attribute name defined in the related model (`path`).
+
+# <a name="formattable"></a>Formattable
+
+Define format on the protected `$formats` variable like bellow.
+
+```php
+<?php namespace App;
+
+use Sofa\Eloquence\Formattable; // trait
+
+class User extends \Eloquent {
+
+    use Formattable;
+
+    protected $formats = [
+        'first_name' => 'strtolower|ucwords',
+        'last_name' => ['strtolower', 'ucwords'],
+        'slug' => '\Str@slug',
+    ];
+}
+```
+
+```php
+$user->first_name = 'john'; // Will set 'John'
+$user->last_name = 'doe'; // Will set 'Doe'
+$user->slug = 'Awesome package!'; // Will set 'awesome-package'
+```
+
+# <a name="roadmap"></a>Roadmap
+- [ ] Set validation rules directly on the model. [Ardent](https://github.com/laravelbook/ardent)
+- [ ] Set relations on an array. (e.g. `protected $relations = ['profile' => 'has_one'];`)
+
+...and much more to come soon!

--- a/src/Formattable.php
+++ b/src/Formattable.php
@@ -1,0 +1,236 @@
+<?php namespace Sofa\Eloquence;
+
+/**
+ * @property array $formats
+ */
+trait Formattable
+{
+    /**
+     * @codeCoverageIgnore
+     *
+     * @inheritdoc
+     */
+    public function setAttribute($key, $value)
+    {
+        if ($this->hasFormating($key)) {
+            return $this->formatAttribute($key, $value);
+        }
+
+        return parent::setAttribute($key, $value);
+    }
+
+    /**
+     * Determine whether a formating exists for an attribute.
+     *
+     * @param string $key
+     * @return boolean
+     */
+    public function hasFormating($key)
+    {
+        $formats = $this->getFormats();
+
+        return array_key_exists($key, $formats);
+    }
+
+    /**
+     * Format the attribute.
+     *
+     * @param string $key
+     * @param string $value
+     * @return string
+     */
+    protected function formatAttribute($key, $value)
+    {
+        $format = $this->getFormatForAttribute($key);
+
+        if ($this->hasMultipleMethod($format)) {
+            return $this->callMultipleMethods($value, $format);
+        }
+
+        return $this->callSingleMethod($value, $format);
+    }
+
+    /**
+     * Determine if the format has multiple methods to call.
+     *
+     * @param string $format
+     * @return boolean
+     */
+    protected function hasMultipleMethod($format)
+    {
+        if (is_array($format) || preg_match('/[|]/', $format)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Call all methods specified.
+     *
+     * @param string       $value
+     * @param array|string $methods
+     * @return string
+     */
+    protected function callMultipleMethods($value, $methods)
+    {
+        $methods = $this->transformToArray($methods);
+
+        foreach ($methods as $method) {
+            $value = $this->callSingleMethod($value, $method);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Call method specified.
+     *
+     * @param string $value
+     * @param string $method
+     * @return string
+     */
+    protected function callSingleMethod($value, $method)
+    {
+        if ($this->isStaticClassCall($method) && $this->hasStaticMethod($method)) {
+            return $this->callStaticMethod($method, $value);
+        }
+
+        if ($this->hasClassMethod($method)) {
+            return $this->callClassMethod($method, $value);
+        }
+
+        if ($this->hasGlobalFunction($method)) {
+            return $this->callGlobalFunction($method, $value);
+        }
+
+        throw new \Exception("Impossible to format the value {$value} - {$format} not found");
+    }
+
+    /**
+     * Transform a string with a pipe to an array.
+     *
+     * @param string $format
+     * @return array
+     */
+    protected function transformToArray($format)
+    {
+        return (is_array($format)) ? $format : explode('|', $format);
+    }
+
+    /**
+     * Call a static method.
+     *
+     * @param string $method
+     * @param string $value
+     * @return string
+     */
+    protected function callStaticMethod($method, $value)
+    {
+        list($class, $action) = $this->parseStaticCall($method);
+
+        return $class::$action($value);
+    }
+
+    /**
+     * Call a global PHP function.
+     *
+     * @param string $function
+     * @param string $value
+     * @return string
+     */
+    protected function callGlobalFunction($function, $value)
+    {
+        return $function($value);
+    }
+
+    /**
+     * Call a specific class's method.
+     *
+     * @param string $method
+     * @param string $value
+     * @return string
+     */
+    protected function callClassMethod($method, $value)
+    {
+        return $this->{$method}($value);
+    }
+
+    /**
+     * Determine whether the method is a static call.
+     *
+     * @param string $method
+     * @return boolean
+     */
+    protected function isStaticClassCall($method)
+    {
+        return (boolean) preg_match('/([A-Za-z]+)[@]([A-Za-z]+)/', $method);
+    }
+
+    /**
+     * Determine whether the method is a class static method.
+     *
+     * @param string $method
+     * @return boolean
+     */
+    protected function hasStaticMethod($method)
+    {
+        list($class, $action) = $this->parseStaticCall($method);
+
+        return method_exists($class, $action);
+    }
+
+    /**
+     * Determine whether the method is a class method.
+     *
+     * @param string $method
+     * @return boolean
+     */
+    protected function hasClassMethod($method)
+    {
+        return method_exists($this, $method);
+    }
+
+    /**
+     * Determine whether the method is a PHP global function.
+     *
+     * @param string $method
+     * @return boolean
+     */
+    protected function hasGlobalFunction($method)
+    {
+        return function_exists($method);
+    }
+
+    /**
+     * Parse method's name.
+     *
+     * @param string $method
+     * @return string
+     */
+    protected function parseStaticCall($method)
+    {
+        return explode('@', $method);
+    }
+
+    /**
+     * Get the format type.
+     *
+     * @param string $key
+     * @return string
+     */
+    protected function getFormatForAttribute($key)
+    {
+        return $this->getFormats()[$key];
+    }
+
+    /**
+     * Get the array of attribute formats.
+     *
+     * @return array
+     */
+    public function getFormats()
+    {
+        return (isset($this->formats)) ? $this->formats : [];
+    }
+}

--- a/tests/FormattableTest.php
+++ b/tests/FormattableTest.php
@@ -1,0 +1,154 @@
+<?php namespace Sofa\Eloquence\Tests;
+
+use Sofa\Eloquence\Formattable;
+
+class FormattableTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->model = new FormattableModelStub();
+    }
+
+    /**
+     * @test
+     */
+    public function it_know_if_its_static_call()
+    {
+        $this->assertTrue($this->model->isStaticClassCall('SomeClass@staticMethod'));
+        $this->assertFalse($this->model->isStaticClassCall('uppercase'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_parse_the_static_call()
+    {
+        list($class, $method) = $this->model->parseStaticCall('SomeClass@staticMethod');
+
+        $this->assertEquals('SomeClass', $class);
+        $this->assertEquals('staticMethod', $method);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allow_us_to_call_methods_with_a_pipe()
+    {
+        $this->assertEquals('Mister', $this->model->formatAttribute('title', 'miStER'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_allow_us_to_call_methods_with_an_array()
+    {
+        $this->assertEquals('Male', $this->model->formatAttribute('gender', 'maLE'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_format_attributes_with_global_function()
+    {
+        $this->assertEquals('Romain', $this->model->formatAttribute('first_name', 'romain'));
+        $this->assertEquals('lanz', $this->model->formatAttribute('last_name', 'Lanz'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_format_attributes_with_class_method()
+    {
+        $this->assertEquals('(555)', $this->model->formatAttribute('phone', '555'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_format_attributes_with_static_method()
+    {
+        $this->assertEquals('DEV', $this->model->formatAttribute('type', 'dev'));
+    }
+}
+
+class FormattableModelStub
+{
+    use Formattable {
+        isStaticClassCall  as protectedIsStaticClassCall;
+        parseStaticCall    as protectedParseStaticCall;
+        hasStaticMethod    as protectedHasStaticMethod;
+        hasClassMethod     as protectedHasClassMethod;
+        hasGlobalFunction  as protectedHasGlobalFunction;
+        callStaticMethod   as protectedCallStaticMethod;
+        callClassMethod    as protectedCallClassMethod;
+        callGlobalFunction as protectedCallGlobalFunction;
+        formatAttribute    as protectedFormatAttribute;
+    }
+
+    protected $formats = [
+        'title' => 'strtolower|ucwords',
+        'gender' => ['strtolower', 'ucwords'],
+        'first_name' => 'ucwords',
+        'last_name' => 'strtolower',
+        'phone' => 'formatPhone',
+        'type' => 'Sofa\Eloquence\Tests\FormatterStub@uppercase',
+    ];
+
+    public function formatPhone($phone)
+    {
+        return "({$phone})";
+    }
+
+    public function parseStaticCall($method)
+    {
+        return $this->protectedParseStaticCall($method);
+    }
+
+    public function isStaticClassCall($method)
+    {
+        return $this->protectedIsStaticClassCall($method);
+    }
+
+    public function hasStaticMethod($method)
+    {
+        return $this->protectedHasStaticMethod($method);
+    }
+
+    public function hasClassMethod($method)
+    {
+        return $this->protectedHasClassMethod($method);
+    }
+
+    public function hasGlobalFunction($method)
+    {
+        return $this->protectedHasGlobalFunction($method);
+    }
+
+    public function callStaticMethod($method, $value)
+    {
+        return $this->protectedCallStaticMethod($method, $value);
+    }
+
+    public function callClassMethod($method, $value)
+    {
+        return $this->protectedCallClassMethod($method, $value);
+    }
+
+    public function callGlobalFunction($function, $value)
+    {
+        return $this->protectedCallGlobalFunction($function, $value);
+    }
+
+    public function formatAttribute($key, $value)
+    {
+        return $this->protectedFormatAttribute($key, $value);
+    }
+}
+
+class FormatterStub
+{
+    public static function uppercase($value)
+    {
+        return strtoupper($value);
+    }
+}


### PR DESCRIPTION
Hey @jarektkaczyk!

:construction: **We have collision problems with our method `setAttribute`. How can we handle that?**

With that we can easily format our attributes.

````php
class User
{
    use Formattable;

    protected $formats = [
        'first_name' => ['strtolower', 'ucwords],
        'last_name' => 'strtolower|ucwords',
        'phone' => 'formatPhone',
        'slug' => '\Str@slug',
    ];

    public function formatPhone($phone)
    {
        return "({$phone})";
    }
}

$user->first_name = 'roMAin'; // Will set 'Romain'
$user->last_name = 'laNZ'; // Will set 'Lanz'
$user->phone = 555; // Will set '(555)'
$user->slug = 'Awesome package!'; // Will set 'awesome-package'
````

I also change the readme to be better and to document `Formattable`.