### PR TITLE
Remove `Formattable` Trait form example

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,6 @@ Feel free to mix the extensions, however mind that the **order of including trai
 
 use Sofa\Eloquence\Eloquence; // base trait
 use Sofa\Eloquence\Mappable; // extension trait
-use Sofa\Eloquence\Formattable; // extension trait
 
 class User extends \Eloquent {
 


### PR DESCRIPTION
Formattable has been removed and replaced by Mutable.