### PR TITLE
Support Model::isDirty() for mapped attributes

### DIFF
--- a/src/Mappable.php
+++ b/src/Mappable.php
@@ -50,6 +50,7 @@ trait Mappable
                 '__isset',
                 '__unset',
                 'queryHook',
+                'isDirty',
             ] as $method) {
             static::hook($method, $hooks->{$method}());
         }

--- a/src/Mappable/Hooks.php
+++ b/src/Mappable/Hooks.php
@@ -38,7 +38,7 @@ class Hooks
 
     public function isDirty()
     {
-        return function($next, $attributes = null, $bag) {
+        return function ($next, $attributes = null, $bag) {
             if (is_array($attributes)) {
                 $attributes = array_map(function ($attribute) {
                     return $this->getMappingForAttribute($attribute) ?: $attribute;

--- a/src/Mappable/Hooks.php
+++ b/src/Mappable/Hooks.php
@@ -36,6 +36,18 @@ class Hooks
         };
     }
 
+    public function isDirty()
+    {
+        return function($next, $attributes = null, $bag) {
+            if (is_array($attributes)) {
+                $attributes = array_map(function ($attribute) {
+                    return $this->getMappingForAttribute($attribute) ?: $attribute;
+                }, $attributes);
+            }
+            return $next($attributes, $bag);
+        };
+    }
+
     /**
      * Register hook on save method.
      *

--- a/tests/MappableTest.php
+++ b/tests/MappableTest.php
@@ -383,6 +383,48 @@ class MappableTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals('new_bam_value', $this->model->mapAttribute('bam'));
     }
 
+    /**
+     * @test
+     * @covers \Sofa\Eloquence\Mappable\Hooks::isDirty
+     */
+    public function mapped_attribute_is_dirty()
+    {
+        // $model->nick maps to $model->ign
+        $model = $this->getModel();
+        $model->nick = 'foo';
+
+        $this->assertTrue($model->isDirty(), 'model should be dirty when mapped attribute is changed');
+        $this->assertTrue($model->isDirty('nick'), 'mapped attribute should be dirty when changed');
+        $this->assertTrue($model->isDirty('ign'), 'original attribute should be dirty when mapped attribute is changed');
+
+        unset($model->nick);
+
+        $this->assertFalse($model->isDirty('nick'), 'mapped attribute should no longer be dirty');
+        $this->assertFalse($model->isDirty('ign'), 'original attribute should no longer be dirty');
+    }
+
+    /**
+     * @test
+     * @covers \Sofa\Eloquence\Mappable\Hooks::isDirty
+     */
+    public function mapped_attributes_multiple_is_dirty()
+    {
+        // $model->nick maps to $model->ign
+        $model = $this->getModel();
+        $model->nick = 'foo';
+
+        $this->assertFalse($model->isDirty('foo', 'bar'), 'should be clean when affected attributes are excluded');
+        $this->assertFalse($model->isDirty(['foo', 'bar']), 'should be clean when affected attributes are excluded');
+
+        $this->assertTrue($model->isDirty('bar', 'nick'), 'should be dirty when affected attribute is included');
+        $this->assertTrue($model->isDirty(['bar', 'nick']), 'should be dirty when affected attribute is included');
+
+        unset($model->nick);
+
+        $this->assertFalse($model->isDirty('nick', 'foo'), 'should not be dirty after affected attributed is cleared');
+        $this->assertFalse($model->isDirty('ign', 'foo'), 'should not be dirty after affected attributed is cleared');
+    }
+
     public function getModel()
     {
         $model = new MappableEloquentStub;


### PR DESCRIPTION
It took me some time to figure out how to do this, but yay it works :)

Why this PR:

I was building a Model observer (Model::saving()), and needed to check if an attribute was changed to be able to update another field. Without this feature of mappable isDirty, you still need to reference the original attribute name, which sort of defeats the purpose of Mappable, so I think it should be part of that trait.

I did not change the behavior of ``getDirty`` because it is used internally by Eloquent, and I prefer not to mess around with that. The original fields are still marked dirty, the only difference is that you can check for mapped attributes as well. Besides, Eloquent does not call ``isDirty`` when saving a model, so it should be safe to override it in this backwards compatible fashion.

Because this feature also requires an update of ``sofa/hookable``, I have made a PR there as well. To run phpunit, please ``git checkout `` [feature/isdirty-composer](https://github.com/boukeversteegh/eloquence/tree/feature/isdirty-composer) which includes the updated dependency. Obviously don't merge that.

```php
class User extends Eloquent
{
   use Eloquence, Mappable;
   protected $maps = ['name' => 'user_name'];
}

$user = new User;
$user->name = 'john';
$user->isDirty('john'); // true
```