### PR TITLE
A hook for the mappable toArray function

### DIFF
--- a/src/Mappable.php
+++ b/src/Mappable.php
@@ -51,6 +51,7 @@ trait Mappable
                 '__isset',
                 '__unset',
                 'queryHook',
+                'toArray'
             ] as $method) {
             static::hook($method, $hooks->{$method}());
         }
@@ -485,6 +486,19 @@ trait Mappable
         return $this->getTarget($this, $segments);
     }
 
+    /**
+     * Determine whether a column is mapped.
+     *
+     * @param $column
+     * @return string
+     */
+    public function isMapping($column)
+    {
+        if (is_null(static::$mappedAttributes)) {
+            $this->parseMappings();
+        }
+        return array_search($column, static::$mappedAttributes);
+    }
     /**
      * Get mapped value.
      *

--- a/src/Mappable/Hooks.php
+++ b/src/Mappable/Hooks.php
@@ -140,4 +140,22 @@ class Hooks
 
         throw new BadMethodCallException("Method [{$method}] doesn't exist on this object.");
     }
+    /**
+     * Register hook on toArray method.
+     *
+     * @return \Closure
+     */
+    public function toArray()
+    {
+        return function ($next, $attributes) {
+            $mappedAttributes = [];
+            foreach ($attributes as $column => $value) {
+                if ($key = $this->isMapping($column)) {
+                    $column = $key;
+                }
+                $mappedAttributes[$column] = $value;
+            };
+            return $next($mappedAttributes);
+        };
+    }
 }

--- a/tests/MappableTest.php
+++ b/tests/MappableTest.php
@@ -383,6 +383,14 @@ class MappableTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals('new_bam_value', $this->model->mapAttribute('bam'));
     }
 
+    /**
+     * @test
+     */
+    public function it_checks_attributed_is_mapping()
+    {
+        $this->assertEquals('alias', $this->model->isMapping('original'));
+    }
+
     public function getModel()
     {
         $model = new MappableEloquentStub;


### PR DESCRIPTION
Make a hook for the toArray function in mappable so we could use the extension in rest services
```php
return response()->json($model);