### PR TITLE
Replace isset() checks for bound items in the service container 

### DIFF
--- a/src/Eloquence.php
+++ b/src/Eloquence.php
@@ -51,7 +51,7 @@ trait Eloquence
         static::observe(new AttributeCleaner);
 
         if (!isset(static::$attributeMutator)) {
-            if (function_exists('app') && isset(app()['eloquence.mutator'])) {
+            if (function_exists('app') && app()->bound('eloquence.mutator')) {
                 static::setAttributeMutator(app('eloquence.mutator'));
             } else {
                 static::setAttributeMutator(new Mutator);

--- a/src/Metable/Attribute.php
+++ b/src/Metable/Attribute.php
@@ -107,7 +107,7 @@ class Attribute extends Model implements AttributeContract
         parent::boot();
 
         if (!isset(static::$attributeMutator)) {
-            if (function_exists('app') && isset(app()['eloquence.mutator'])) {
+            if (function_exists('app') && app()->bound('eloquence.mutator')) {
                 static::$attributeMutator = app('eloquence.mutator');
             } else {
                 static::$attributeMutator = new Mutator;

--- a/src/Validable.php
+++ b/src/Validable.php
@@ -51,7 +51,7 @@ trait Validable
         static::observe(new Observer);
 
         if (!static::$validatorFactory) {
-            if (function_exists('app') && isset(app()['validator'])) {
+            if (function_exists('app') && app()->bound('validator')) {
                 static::setValidatorFactory(app('validator'));
             }
         }


### PR DESCRIPTION
Replace isset() checks for bound items in the service container with the container provided bound() function. Fixes #34.