### PR TITLE
Add unicode modifier to regex in splitString

### DIFF
--- a/src/Searchable/Parser.php
+++ b/src/Searchable/Parser.php
@@ -103,7 +103,7 @@ class Parser implements ParserContract
      */
     protected function splitString($query)
     {
-        preg_match_all('/(?<=")[\w ][^"]+(?=")|(?<=\s|^)[^\s"]+(?=\s|$)/', $query, $matches);
+        preg_match_all('/(?<=")[\w ][^"]+(?=")|(?<=\s|^)[^\s"]+(?=\s|$)/u', $query, $matches);
 
         return reset($matches);
     }


### PR DESCRIPTION
Hi

When using a query string starting with unicode character, for example:
```php
Task::search('"żopa żopa"', $columns)->get();
```
the `preg_match_all` in `Sofa\Eloquence\Searchable\Parser::splitString()` doesn't match any words.

Proposed fix is to add an unicode modifier to the `preg_match_all` regex.