### PR TITLE
FIX Mappable Contract

### DIFF
--- a/src/Contracts/Mappable.php
+++ b/src/Contracts/Mappable.php
@@ -2,9 +2,11 @@
 
 namespace Sofa\Eloquence\Contracts;
 
+use Closure;
+
 interface Mappable
 {
-    public static function hook($method, $hook);
+    public static function hook($method, Closure $hook);
     public function getAttribute($key);
     public function setAttribute($key, $value);
     public function hasMapping($key);


### PR DESCRIPTION
Add 'Closure' typehint to Sofa\Eloquence\Contracts\Mappable::hook to make it compatible with Sofa\Eloquence\Eloquence::hook