### PR TITLE
Fix the Mappable trait inheritance

### DIFF
--- a/src/Mappable.php
+++ b/src/Mappable.php
@@ -24,7 +24,7 @@ trait Mappable
      *
      * @var array
      */
-    protected static $mappedAttributes;
+    protected $mappedAttributes;
 
     /**
      * Related mapped objects to save along with the mappable instance.
@@ -410,7 +410,7 @@ trait Mappable
     public function getMappingForAttribute($key)
     {
         if ($this->hasMapping($key)) {
-            return static::$mappedAttributes[$key];
+            return $this->mappedAttributes[$key];
         }
     }
 
@@ -433,11 +433,11 @@ trait Mappable
      */
     public function hasMapping($key)
     {
-        if (is_null(static::$mappedAttributes)) {
+        if (is_null($this->mappedAttributes)) {
             $this->parseMappings();
         }
 
-        return array_key_exists((string) $key, static::$mappedAttributes);
+        return array_key_exists((string) $key, $this->mappedAttributes);
     }
 
     /**
@@ -447,13 +447,13 @@ trait Mappable
      */
     protected function parseMappings()
     {
-        static::$mappedAttributes = [];
+        $this->mappedAttributes = [];
 
         foreach ($this->getMaps() as $attribute => $mapping) {
             if (is_array($mapping)) {
                 $this->parseImplicitMapping($mapping, $attribute);
             } else {
-                static::$mappedAttributes[$attribute] = $mapping;
+                $this->mappedAttributes[$attribute] = $mapping;
             }
         }
     }
@@ -468,7 +468,7 @@ trait Mappable
     protected function parseImplicitMapping($attributes, $target)
     {
         foreach ($attributes as $attribute) {
-            static::$mappedAttributes[$attribute] = "{$target}.{$attribute}";
+            $this->mappedAttributes[$attribute] = "{$target}.{$attribute}";
         }
     }
 

--- a/tests/MappableTest.php
+++ b/tests/MappableTest.php
@@ -383,9 +383,9 @@ class MappableTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals('new_bam_value', $this->model->mapAttribute('bam'));
     }
 
-    public function getModel()
+    public function getModel($model = null)
     {
-        $model = new MappableEloquentStub;
+        $model = $model ?: new MappableEloquentStub;
         $grammarClass = 'Illuminate\Database\Query\Grammars\SQLiteGrammar';
         $processorClass = 'Illuminate\Database\Query\Processors\SQLiteProcessor';
         $grammar = new $grammarClass;

--- a/tests/MappableTest.php
+++ b/tests/MappableTest.php
@@ -383,6 +383,20 @@ class MappableTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals('new_bam_value', $this->model->mapAttribute('bam'));
     }
 
+    /**
+     * @test
+     */
+    public function it_inherits_base_model_proper()
+    {
+        $q = $this->getModel(new UserStub)->select(['id', 'name'])->where('id', '>', 0);
+        $expectedSql = 'select "user_stubs"."usr_id", "user_stubs"."usr_name" from "user_stubs" where "usr_id" > ?';
+        $this->assertEquals($expectedSql, $q->toSql());
+
+        $q = $this->getModel(new BookStub)->select(['id', 'name', 'pages'])->where('id', '>', 0);
+        $expectedSql = 'select "book_stubs"."bk_id", "book_stubs"."bk_name", "book_stubs"."bk_pages" from "book_stubs" where "bk_id" > ?';
+        $this->assertEquals($expectedSql, $q->toSql());
+    }
+
     public function getModel($model = null)
     {
         $model = $model ?: new MappableEloquentStub;
@@ -529,4 +543,25 @@ class MappableFarRelatedStub extends Model {
 
 class MappablePolymorphicStub extends Model {
     protected $table = 'companies';
+}
+
+
+
+class BaseModelStub extends Model {
+    use Eloquence, Mappable;
+}
+
+class UserStub extends BaseModelStub {
+    protected $maps = [
+        'id' => 'usr_id',
+        'name' => 'usr_name',
+    ];
+}
+
+class BookStub extends BaseModelStub {
+    protected $maps = [
+        'id' => 'bk_id',
+        'name' => 'bk_name',
+        'pages' => 'bk_pages',
+    ];
 }


### PR DESCRIPTION
I've the same issue that @sarahkemp described in the #46: I can't use models that inherit some base model which uses the Mappable trait.

The fix makes the mapping a bit slower because now it has to be executed for every instance, but I think it's not a big deal. Implementing some sort of cache would be an overhead in that case.