### PR TITLE
Fix for aliased columns in mappable and metable select

### DIFF
--- a/src/Eloquence.php
+++ b/src/Eloquence.php
@@ -91,13 +91,11 @@ trait Eloquence
      */
     protected function extractColumnAlias($column)
     {
-        $alias = $column;
-
         if (strpos($column, ' as ') !== false) {
-            list($column, $alias) = explode(' as ', $column);
+            return explode(' as ', $column);
         }
 
-        return [$column, $alias];
+        return [$column, null];
     }
 
     /**

--- a/src/Mappable.php
+++ b/src/Mappable.php
@@ -107,7 +107,7 @@ trait Mappable
 
                 $columns[$key] = "{$table}.{$mapped}";
 
-                if ($as !== $mapped) {
+                if ($as !== null && $as !== $mapped) {
                     $columns[$key] .= " as {$as}";
                 }
 

--- a/src/Metable.php
+++ b/src/Metable.php
@@ -93,7 +93,7 @@ trait Metable
             if ($this->hasColumn($column)) {
                 $select = "{$this->getTable()}.{$column}";
 
-                if ($column !== $alias) {
+                if ($alias !== null && $column !== $alias) {
                     $select .= " as {$alias}";
                 }
 
@@ -101,7 +101,7 @@ trait Metable
             } elseif (is_string($column) && $column != '*' && strpos($column, '.') === false) {
                 $table = $this->joinMeta($query, $column);
 
-                $columns[$key] = "{$table}.meta_value as {$alias}";
+                $columns[$key] = sprintf("%s.meta_value as %s", $table, ($alias ? $alias : $column));
             }
         }
 

--- a/tests/MappableTest.php
+++ b/tests/MappableTest.php
@@ -24,10 +24,10 @@ class MappableTest extends \PHPUnit_Framework_TestCase {
      */
     public function mapped_select()
     {
-        $sql = 'select "profiles"."last_name", "users"."id", "users"."ign" from "users" '.
+        $sql = 'select "profiles"."last_name", "users"."id", "users"."ign", "users"."gender" as "alias" from "users" '.
                 'left join "profiles" on "users"."profile_id" = "profiles"."id"';
 
-        $query = $this->getModel()->select('last_name', 'id', 'nick');
+        $query = $this->getModel()->select('last_name', 'id', 'nick', 'sex as alias');
 
         $this->assertEquals($sql, $query->toSql());
     }
@@ -482,6 +482,7 @@ class MappableEloquentStub extends Model {
         'first_name' => 'profile.first_name',
         'profile'    => ['last_name', 'age'],
         'nick'       => 'ign',
+        'sex'        => 'gender',
         'photo'      => 'account.photo',
         'address'    => 'account.address',
         'avatar'     => 'profile.image.path',


### PR DESCRIPTION
When we do a select like select('field1') and field1 and this field is mapped by eloquence as 'column1' it will make a query like "select column1 as field1". 
this results in that the attributes is filled with 'field1' instead of column1. 
The query should be “select column1” so mappable could do his work.

This is an issue when we use the toArray method in conjunction with the visible option of eloquent.
