### PR TITLE
Do not add the alias to the select if the alias equals the mapped col…

### DIFF
--- a/src/Mappable.php
+++ b/src/Mappable.php
@@ -107,7 +107,7 @@ trait Mappable
 
                 $columns[$key] = "{$table}.{$mapped}";
 
-                if ($as !== $mapped) {
+                if ($as !== $mapped && $as !== $column) {
                     $columns[$key] .= " as {$as}";
                 }
 

--- a/tests/MappableTest.php
+++ b/tests/MappableTest.php
@@ -24,10 +24,10 @@ class MappableTest extends \PHPUnit_Framework_TestCase {
      */
     public function mapped_select()
     {
-        $sql = 'select "profiles"."last_name", "users"."id", "users"."ign" from "users" '.
+        $sql = 'select "profiles"."last_name", "users"."id", "users"."ign", "users"."gender" as "alias" from "users" '.
                 'left join "profiles" on "users"."profile_id" = "profiles"."id"';
 
-        $query = $this->getModel()->select('last_name', 'id', 'nick');
+        $query = $this->getModel()->select('last_name', 'id', 'nick', 'sex as alias');
 
         $this->assertEquals($sql, $query->toSql());
     }
@@ -496,6 +496,7 @@ class MappableEloquentStub extends Model {
         'first_name' => 'profile.first_name',
         'profile'    => ['last_name', 'age'],
         'nick'       => 'ign',
+        'sex'        => 'gender',
         'photo'      => 'account.photo',
         'address'    => 'account.address',
         'avatar'     => 'profile.image.path',


### PR DESCRIPTION
When we do a select like select('field1') and field1 and this field is mapped by eloquence as 'column1' it will make a query like "select column1 as field1".
this results in that the attributes is filled with 'field1' instead of column1.
The query should be “select column1” so mappable could do his work.

This is an issue when we use the toArray method in conjunction with the visible option of eloquent.