### PR TITLE
Fix warning when running phpunit

### DIFF
--- a/tests/MetableTest.php
+++ b/tests/MetableTest.php
@@ -620,7 +620,7 @@ class MetableTest extends \PHPUnit_Framework_TestCase {
 }
 
 class ParentModel extends Model {
-    public function save()
+    public function save(array $options = [])
     {
         return true;
     }


### PR DESCRIPTION
This is just a "fix" to remove the following warning.

> PHP Warning:  Declaration of Sofa\Eloquence\Tests\ParentModel::save() should be compatible with Illuminate\Database\Eloquent\Model::save(array $options = Array) in /Users/lukasoppermann/Code/testelo/tests/MetableTest.php on line 627