### PR TITLE
Meta group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
 
 install:
   - travis_retry composer require satooshi/php-coveralls:~0.6@stable

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
     ],
     "require": {
         "php": ">=5.6.4",
-        "sofa/hookable": "5.3.*",
-        "illuminate/database": "5.3.*|5.4.*"
+        "sofa/hookable": "5.4.*",
+        "illuminate/database": "5.4.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0",

--- a/src/Contracts/Attribute.php
+++ b/src/Contracts/Attribute.php
@@ -25,7 +25,12 @@ interface Attribute
      * @return string
      */
     public function getKey();
-
+    /**
+     * Get the meta attribute group.
+     *
+     * @return string
+     */
+    public function getMetaGroup();
     /**
      * Set value of the meta attribute.
      *

--- a/src/Contracts/AttributeBag.php
+++ b/src/Contracts/AttributeBag.php
@@ -4,6 +4,7 @@ namespace Sofa\Eloquence\Contracts;
 
 interface AttributeBag
 {
-    public function set($key, $value);
+    public function set($key, $value, $group = null);
     public function getValue($key);
+    public function getMetaByGroup($group);
 }

--- a/src/Mappable.php
+++ b/src/Mappable.php
@@ -273,7 +273,7 @@ trait Mappable
                         ? $parent->getMorphClass()
                         : $related->getMorphClass();
 
-                    $join->where($relation->getMorphType(), '=', $morphClass);
+                    $join->where($relation->getQualifiedMorphType(), '=', $morphClass);
                 }
             });
         }
@@ -306,11 +306,11 @@ trait Mappable
     protected function getJoinKeys(Relation $relation)
     {
         if ($relation instanceof HasOne || $relation instanceof MorphOne) {
-            return [$relation->getForeignKey(), $relation->getQualifiedParentKeyName()];
+            return [$relation->getQualifiedForeignKeyName(), $relation->getQualifiedParentKeyName()];
         }
 
         if ($relation instanceof BelongsTo && !$relation instanceof MorphTo) {
-            return [$relation->getQualifiedForeignKey(), $relation->getQualifiedOtherKeyName()];
+            return [$relation->getQualifiedForeignKey(), $relation->getQualifiedOwnerKeyName()];
         }
 
         $class = get_class($relation);

--- a/src/Metable.php
+++ b/src/Metable.php
@@ -404,7 +404,16 @@ trait Metable
     {
         return $this->getMetaAttributes()->getValue($key);
     }
-
+    /**
+     * Get meta attribute values by group.
+     *
+     * @param  string $key
+     * @return mixed
+     */
+    public function getMetaByGroup($group)
+    {
+        return $this->getMetaAttributes()->getMetaByGroup($group);
+    }
     /**
      * Set meta attribute.
      *
@@ -412,9 +421,9 @@ trait Metable
      * @param  mixed  $value
      * @return void
      */
-    public function setMeta($key, $value)
+    public function setMeta($key, $value, $group = null)
     {
-        $this->getMetaAttributes()->set($key, $value);
+        $this->getMetaAttributes()->set($key, $value, $group);
     }
 
     /**

--- a/src/Metable/Attribute.php
+++ b/src/Metable/Attribute.php
@@ -72,7 +72,7 @@ class Attribute extends Model implements AttributeContract
      *
      * @var array
      */
-    protected $visible = ['meta_key', 'meta_value', 'meta_type'];
+    protected $visible = ['meta_key', 'meta_value', 'meta_type', 'meta_group'];
 
     /**
      * Create new attribute instance.
@@ -80,7 +80,7 @@ class Attribute extends Model implements AttributeContract
      * @param string|array  $key
      * @param mixed  $value
      */
-    public function __construct($key = null, $value = null)
+    public function __construct($key = null, $value = null, $group = null)
     {
         // default behaviour
         if (is_array($key)) {
@@ -89,7 +89,7 @@ class Attribute extends Model implements AttributeContract
             parent::__construct();
 
             if (is_string($key)) {
-                $this->set($key, $value);
+                $this->set($key, $value, $group);
             }
         }
     }
@@ -119,11 +119,13 @@ class Attribute extends Model implements AttributeContract
      *
      * @param string $key
      * @param mixed  $value
+     * @param string $group
      */
-    protected function set($key, $value)
+    protected function set($key, $value, $group = 'default')
     {
         $this->setMetaKey($key);
         $this->setValue($value);
+        $this->setMetaGroup($group);
     }
 
     /**
@@ -162,6 +164,15 @@ class Attribute extends Model implements AttributeContract
     }
 
     /**
+     * Get the meta attribute group.
+     *
+     * @return string
+     */
+    public function getMetaGroup()
+    {
+        return $this->attributes['meta_group'];
+    }
+    /**
      * Cast value to proper type.
      *
      * @return mixed
@@ -194,7 +205,21 @@ class Attribute extends Model implements AttributeContract
 
         $this->attributes['meta_key'] = $key;
     }
+    /**
+     * Set group of the meta attribute.
+     *
+     * @param string $group
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function setMetaGroup($group = null)
+    {
+        if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $group) && $group !== null) {
+            throw new InvalidArgumentException("Provided group [{$group}] is not valid variable name.");
+        }
 
+        $this->attributes['meta_group'] = $group;
+    }
     /**
      * Set type of the meta attribute.
      *

--- a/src/Metable/AttributeBag.php
+++ b/src/Metable/AttributeBag.php
@@ -27,16 +27,16 @@ class AttributeBag extends Collection implements AttributeBagContract
      * @param  mixed $value
      * @return $this
      */
-    public function set($key, $value = null)
+    public function set($key, $value = null, $group = null)
     {
         if ($key instanceof Attribute) {
             return $this->setInstance($key);
         }
 
         if ($this->has($key)) {
-            $this->update($key, $value);
+            $this->update($key, $value, $group);
         } else {
-            $this->items[$key] = $this->newAttribute($key, $value);
+            $this->items[$key] = $this->newAttribute($key, $value, $group);
         }
 
         return $this;
@@ -85,14 +85,16 @@ class AttributeBag extends Collection implements AttributeBagContract
      * @param  mixed  $value
      * @return $this
      */
-    protected function update($key, $value = null)
+    protected function update($key, $value = null, $group = null)
     {
         if ($key instanceof Attribute) {
             $value = $key->getValue();
+            $group = $key->getMetaGroup();
             $key = $key->getMetaKey();
         }
 
         $this->get($key)->setValue($value);
+        $this->get($key)->setMetaGroup($group);
 
         return $this;
     }
@@ -104,9 +106,9 @@ class AttributeBag extends Collection implements AttributeBagContract
      * @param  mixed  $value
      * @return \Sofa\Eloquence\Metable\Attribute
      */
-    protected function newAttribute($key, $value)
+    protected function newAttribute($key, $value, $group = null)
     {
-        return new Attribute($key, $value);
+        return new Attribute($key, $value, $group);
     }
 
     /**
@@ -121,7 +123,16 @@ class AttributeBag extends Collection implements AttributeBagContract
             return $attribute->getValue();
         }
     }
-
+    /**
+     * Get attribute values by group.
+     *
+     * @param  string $group
+     * @return mixed
+     */
+    public function getMetaByGroup($group)
+    {
+        return $this->where('meta_group', $group);
+    }
     /**
      * Get collection as key-value array.
      *

--- a/src/Metable/CreateMetaAttributesTable.php
+++ b/src/Metable/CreateMetaAttributesTable.php
@@ -31,6 +31,7 @@ class CreateMetaAttributesTable extends Migration
             $table->string('meta_key');
             $table->longText('meta_value');
             $table->string('meta_type')->default('string');
+            $table->string('meta_group')->nullable();
             $table->morphs('metable');
 
             $table->index('meta_key');

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -87,4 +87,20 @@ class Builder extends \Illuminate\Database\Query\Builder
 
         $this->backups = $this->bindingBackups = [];
     }
+
+    /**
+     * Run a pagination count query.
+     *
+     * @param  array  $columns
+     * @return array
+     */
+    protected function runPaginationCountQuery($columns = ['*'])
+    {
+        $bindings = $this->from instanceof Subquery ? ['order'] : ['select', 'order'];
+
+        return $this->cloneWithout(['columns', 'orders', 'limit', 'offset'])
+                    ->cloneWithoutBindings($bindings)
+                    ->setAggregate('count', $this->withoutSelectAliases($columns))
+                    ->get()->all();
+    }
 }

--- a/src/Relations/Joiner.php
+++ b/src/Relations/Joiner.php
@@ -135,7 +135,7 @@ class Joiner implements JoinerContract
         $join = (new Join($this->query, $type, $table))->on($fk, '=', $pk);
 
         if ($relation instanceof MorphOneOrMany) {
-            $join->where($relation->getMorphType(), '=', $parent->getMorphClass());
+            $join->where($relation->getQualifiedMorphType(), '=', $parent->getMorphClass());
         }
 
         return $join;
@@ -153,10 +153,10 @@ class Joiner implements JoinerContract
     {
         if ($relation instanceof BelongsToMany) {
             $table = $relation->getTable();
-            $fk    = $relation->getForeignKey();
+            $fk = $relation->getQualifiedForeignKeyName();
         } else {
             $table = $relation->getParent()->getTable();
-            $fk    = $table.'.'.$parent->getForeignKey();
+            $fk = $relation->getQualifiedFirstKeyName();
         }
 
         $pk = $parent->getQualifiedKeyName();
@@ -181,19 +181,19 @@ class Joiner implements JoinerContract
         }
 
         if ($relation instanceof HasOneOrMany) {
-            return [$relation->getForeignKey(), $relation->getQualifiedParentKeyName()];
+            return [$relation->getQualifiedForeignKeyName(), $relation->getQualifiedParentKeyName()];
         }
 
         if ($relation instanceof BelongsTo) {
-            return [$relation->getQualifiedForeignKey(), $relation->getQualifiedOtherKeyName()];
+            return [$relation->getQualifiedForeignKey(), $relation->getQualifiedOwnerKeyName()];
         }
 
         if ($relation instanceof BelongsToMany) {
-            return [$relation->getOtherKey(), $relation->getRelated()->getQualifiedKeyName()];
+            return [$relation->getQualifiedRelatedKeyName(), $relation->getRelated()->getQualifiedKeyName()];
         }
 
         if ($relation instanceof HasManyThrough) {
-            $fk = $relation->getRelated()->getTable().'.'.$relation->getParent()->getForeignKey();
+            $fk = $relation->getQualifiedFarKeyName();
 
             return [$fk, $relation->getParent()->getQualifiedKeyName()];
         }

--- a/tests/AttributeBagTest.php
+++ b/tests/AttributeBagTest.php
@@ -97,6 +97,18 @@ class AttributeBagTest extends \PHPUnit_Framework_TestCase {
     /**
      * @test
      */
+    public function it_gets_attributes_by_group()
+    {
+        $bag = $this->getBag();
+
+        $this->assertEquals([
+            'baz' => $bag->get('baz'),
+            'bar' => $bag->get('bar'),
+        ], $bag->getMetaByGroup('group')->toArray());
+    }
+    /**
+     * @test
+     */
     public function it_accepts_only_valid_attribute()
     {
         $bag = $this->getBag();
@@ -110,7 +122,8 @@ class AttributeBagTest extends \PHPUnit_Framework_TestCase {
     {
         return new AttributeBag([
             new Attribute('foo', 'bar'),
-            new Attribute('baz', 'bax')
+            new Attribute('baz', 'bax','group'),
+            new Attribute('bar', 'baz','group'),
         ]);
     }
 }

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -99,6 +99,13 @@ class AttributeTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertEquals('color', $attribute->getMetaKey());
         $this->assertEquals('red', $attribute->getValue());
+        $this->assertEquals(NULL, $attribute->getMetaGroup());
+
+        $attribute = $this->getAttributeWithGroup('group');
+
+        $this->assertEquals('color', $attribute->getMetaKey());
+        $this->assertEquals('red', $attribute->getValue());
+        $this->assertEquals('group', $attribute->getMetaGroup());
     }
 
     /**
@@ -131,6 +138,11 @@ class AttributeTest extends \PHPUnit_Framework_TestCase {
     protected function getAttribute()
     {
         return new Attribute('color', 'red');
+    }
+
+    protected function getAttributeWithGroup($group = null)
+    {
+        return new Attribute('color', 'red', $group);
     }
 }
 

--- a/tests/JoinerTest.php
+++ b/tests/JoinerTest.php
@@ -125,11 +125,6 @@ class JoinerUserStub extends Model {
         return $this->hasManyThrough($related, $through, 'user_id', 'company_id');
     }
 
-    public function getForeignKey()
-    {
-        return 'user_id';
-    }
-
     public function posts()
     {
         return $this->hasMany('Sofa\Eloquence\Tests\JoinerPostStub', 'user_id');
@@ -157,11 +152,6 @@ class JoinerProfileStub extends Model {
 
 class JoinerCompanyStub extends Model {
     protected $table = 'companies';
-
-    public function getForeignKey()
-    {
-        return 'company_id';
-    }
 }
 
 class JoinerPostStub extends Model {

--- a/tests/MetableTest.php
+++ b/tests/MetableTest.php
@@ -7,6 +7,7 @@ use Sofa\Eloquence\Builder;
 use Sofa\Eloquence\Metable;
 use Sofa\Eloquence\Eloquence;
 use Sofa\Eloquence\ArgumentBag;
+use Sofa\Eloquence\Metable\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Query\Builder as Query;
@@ -522,7 +523,7 @@ class MetableTest extends \PHPUnit_Framework_TestCase {
     public function it_sets_attribute_on_the_bag()
     {
         $bag = $this->getBag();
-        $bag->shouldReceive('set')->with('color', 'red')->once();
+        $bag->shouldReceive('set')->with('color', 'red', NULL)->once();
 
         $model = $this->getMetableStub();
         $model->shouldReceive('getMetaAttributes')->andReturn($bag);
@@ -542,6 +543,34 @@ class MetableTest extends \PHPUnit_Framework_TestCase {
         $model->shouldReceive('getMetaAttributes')->andReturn($bag);
 
         $this->assertEquals(['color' => 'red'], $model->getMetaAttributesArray());
+    }
+
+    /**
+     * @test
+     */
+    public function it_sets_attribute_with_group_on_the_bag()
+    {
+        $bag = $this->getBag();
+        $bag->shouldReceive('set')->with('color', 'red', 'group')->once();
+
+        $model = $this->getMetableStub();
+        $model->shouldReceive('getMetaAttributes')->andReturn($bag);
+
+        $model->setMeta('color', 'red', 'group');
+    }
+
+    /**
+     * @test
+     */
+    public function it_gets_attribute_with_group_on_the_bag()
+    {
+        $model = $this->getModel();
+
+        $model->setMeta('test','1','group');
+        $model->setMeta('test2','2',null);
+
+        $this->assertEquals($model->getMetaByGroup('group')->toArray(), ['test' => new Attribute('test','1','group')]);
+
     }
 
     /**

--- a/tests/MetableTest.php
+++ b/tests/MetableTest.php
@@ -182,7 +182,7 @@ class MetableTest extends \PHPUnit_Framework_TestCase {
     public function meta_whereExists()
     {
         $sql = 'select * from "metables" where exists (select 1 from "metables" where exists (select * from "meta_attributes" '.
-                'where "meta_attributes"."metable_id" = "metables"."id" and "meta_attributes"."metable_type" = ? '.
+                'where "metables"."id" = "meta_attributes"."metable_id" and "meta_attributes"."metable_type" = ? '.
                 'and "meta_key" = ? and "meta_value" > 10))';
 
         $model = $this->getModel();
@@ -202,7 +202,7 @@ class MetableTest extends \PHPUnit_Framework_TestCase {
     public function meta_whereDates($type, $placeholder)
     {
         $sql = 'select * from "metables" where "name" = ? and exists (select * from "meta_attributes" '.
-                'where "meta_attributes"."metable_id" = "metables"."id" and "meta_attributes"."metable_type" = ? '.
+                'where "metables"."id" = "meta_attributes"."metable_id" and "meta_attributes"."metable_type" = ? '.
                 'and "meta_key" = ? and strftime(\''.$placeholder.'\', "meta_value") = ?)';
 
         $query = $this->getModel()->where('name', 'jarek')->{"where{$type}"}('published_at', '=', 'date_value');
@@ -227,7 +227,7 @@ class MetableTest extends \PHPUnit_Framework_TestCase {
     public function meta_orWhereNull()
     {
         $sql = 'select * from "metables" where "name" = ? or not exists (select * from "meta_attributes" '.
-                'where "meta_attributes"."metable_id" = "metables"."id" and "meta_attributes"."metable_type" = ? '.
+                'where "metables"."id" = "meta_attributes"."metable_id" and "meta_attributes"."metable_type" = ? '.
                 'and "meta_key" = ?)';
 
         $query = $this->getModel()->where('name', 'jarek')->orWhereNull('color');
@@ -242,7 +242,7 @@ class MetableTest extends \PHPUnit_Framework_TestCase {
     public function meta_orWhereNotNull()
     {
         $sql = 'select * from "metables" where "name" = ? or exists (select * from "meta_attributes" '.
-                'where "meta_attributes"."metable_id" = "metables"."id" and "meta_attributes"."metable_type" = ? '.
+                'where "metables"."id" = "meta_attributes"."metable_id" and "meta_attributes"."metable_type" = ? '.
                 'and "meta_key" = ?)';
 
         $query = $this->getModel()->where('name', 'jarek')->orWhereNotNull('color');
@@ -257,7 +257,7 @@ class MetableTest extends \PHPUnit_Framework_TestCase {
     public function meta_whereNotNull()
     {
         $sql = 'select * from "metables" where "name" = ? and exists (select * from "meta_attributes" '.
-                'where "meta_attributes"."metable_id" = "metables"."id" and "meta_attributes"."metable_type" = ? '.
+                'where "metables"."id" = "meta_attributes"."metable_id" and "meta_attributes"."metable_type" = ? '.
                 'and "meta_key" = ?)';
 
         $query = $this->getModel()->where('name', 'jarek')->whereNotNull('color');
@@ -272,7 +272,7 @@ class MetableTest extends \PHPUnit_Framework_TestCase {
     public function meta_whereNull()
     {
         $sql = 'select * from "metables" where "name" = ? and not exists (select * from "meta_attributes" '.
-                'where "meta_attributes"."metable_id" = "metables"."id" and "meta_attributes"."metable_type" = ? '.
+                'where "metables"."id" = "meta_attributes"."metable_id" and "meta_attributes"."metable_type" = ? '.
                 'and "meta_key" = ?)';
 
         $query = $this->getModel()->where('name', 'jarek')->whereNull('color');
@@ -287,7 +287,7 @@ class MetableTest extends \PHPUnit_Framework_TestCase {
     public function meta_whereNotBetween()
     {
         $sql = 'select * from "metables" where "name" = ? and not exists (select * from "meta_attributes" '.
-                'where "meta_attributes"."metable_id" = "metables"."id" and "meta_attributes"."metable_type" = ? '.
+                'where "metables"."id" = "meta_attributes"."metable_id" and "meta_attributes"."metable_type" = ? '.
                 'and "meta_key" = ? and "meta_value" >= ? and "meta_value" <= ?)';
 
         $query = $this->getModel()->where('name', 'jarek')->whereNotBetween('size', ['5','10']);
@@ -302,7 +302,7 @@ class MetableTest extends \PHPUnit_Framework_TestCase {
     public function meta_whereBetween_numeric()
     {
         $sql = 'select * from "metables" where "name" = ? and exists (select * from "meta_attributes" '.
-                'where "meta_attributes"."metable_id" = "metables"."id" and "meta_attributes"."metable_type" = ? '.
+                'where "metables"."id" = "meta_attributes"."metable_id" and "meta_attributes"."metable_type" = ? '.
                 'and "meta_key" = ? and "meta_value" >= 5 and "meta_value" <= 10.5)';
 
         $model = $this->getModel();
@@ -320,7 +320,7 @@ class MetableTest extends \PHPUnit_Framework_TestCase {
     public function meta_whereBetween_string()
     {
         $sql = 'select * from "metables" where "name" = ? and exists (select * from "meta_attributes" '.
-                'where "meta_attributes"."metable_id" = "metables"."id" and "meta_attributes"."metable_type" = ? '.
+                'where "metables"."id" = "meta_attributes"."metable_id" and "meta_attributes"."metable_type" = ? '.
                 'and "meta_key" = ? and "meta_value" >= ? and "meta_value" <= ?)';
 
         $query = $this->getModel()->where('name', 'jarek')->whereBetween('size', ['M','L']);
@@ -335,7 +335,7 @@ class MetableTest extends \PHPUnit_Framework_TestCase {
     public function meta_orWhereBetween()
     {
         $sql = 'select * from "metables" where "name" = ? or exists (select * from "meta_attributes" '.
-                'where "meta_attributes"."metable_id" = "metables"."id" and "meta_attributes"."metable_type" = ? '.
+                'where "metables"."id" = "meta_attributes"."metable_id" and "meta_attributes"."metable_type" = ? '.
                 'and "meta_key" = ? and "meta_value" >= ? and "meta_value" <= ?)';
 
         $query = $this->getModel()->where('name', 'jarek')->orWhereBetween('size', ['M','L']);
@@ -350,7 +350,7 @@ class MetableTest extends \PHPUnit_Framework_TestCase {
     public function meta_orWhereNotBetween()
     {
         $sql = 'select * from "metables" where "name" = ? or not exists (select * from "meta_attributes" '.
-                'where "meta_attributes"."metable_id" = "metables"."id" and "meta_attributes"."metable_type" = ? '.
+                'where "metables"."id" = "meta_attributes"."metable_id" and "meta_attributes"."metable_type" = ? '.
                 'and "meta_key" = ? and "meta_value" >= ? and "meta_value" <= ?)';
 
         $query = $this->getModel()->where('name', 'jarek')->orWhereNotBetween('size', ['M','L']);
@@ -365,7 +365,7 @@ class MetableTest extends \PHPUnit_Framework_TestCase {
     public function meta_orWhereNotIn()
     {
         $sql = 'select * from "metables" where "name" = ? or not exists (select * from "meta_attributes" '.
-                'where "meta_attributes"."metable_id" = "metables"."id" and "meta_attributes"."metable_type" = ? '.
+                'where "metables"."id" = "meta_attributes"."metable_id" and "meta_attributes"."metable_type" = ? '.
                 'and "meta_key" = ? and "meta_value" in (?, ?, ?))';
 
         $query = $this->getModel()->where('name', 'jarek')->orWhereNotIn('size', ['L', 'M', 'S']);
@@ -380,7 +380,7 @@ class MetableTest extends \PHPUnit_Framework_TestCase {
     public function meta_whereNotIn()
     {
         $sql = 'select * from "metables" where "name" = ? and not exists (select * from "meta_attributes" '.
-                'where "meta_attributes"."metable_id" = "metables"."id" and "meta_attributes"."metable_type" = ? '.
+                'where "metables"."id" = "meta_attributes"."metable_id" and "meta_attributes"."metable_type" = ? '.
                 'and "meta_key" = ? and "meta_value" in (?, ?, ?))';
 
         $query = $this->getModel()->where('name', 'jarek')->whereNotIn('size', ['L', 'M', 'S']);
@@ -395,7 +395,7 @@ class MetableTest extends \PHPUnit_Framework_TestCase {
     public function meta_whereIn()
     {
         $sql = 'select * from "metables" where "name" = ? and exists (select * from "meta_attributes" '.
-                'where "meta_attributes"."metable_id" = "metables"."id" and "meta_attributes"."metable_type" = ? '.
+                'where "metables"."id" = "meta_attributes"."metable_id" and "meta_attributes"."metable_type" = ? '.
                 'and "meta_key" = ? and "meta_value" in (?, ?, ?))';
 
         $query = $this->getModel()->where('name', 'jarek')->whereIn('size', ['L', 'M', 55]);
@@ -410,7 +410,7 @@ class MetableTest extends \PHPUnit_Framework_TestCase {
     public function meta_orWhereIn()
     {
         $sql = 'select * from "metables" where "name" = ? or exists (select * from "meta_attributes" '.
-                'where "meta_attributes"."metable_id" = "metables"."id" and "meta_attributes"."metable_type" = ? '.
+                'where "metables"."id" = "meta_attributes"."metable_id" and "meta_attributes"."metable_type" = ? '.
                 'and "meta_key" = ? and "meta_value" in (?, ?, ?))';
 
         $query = $this->getModel()->where('name', 'jarek')->orWhereIn('size', ['L', 'M', 'S']);
@@ -425,7 +425,7 @@ class MetableTest extends \PHPUnit_Framework_TestCase {
     public function meta_orWhere()
     {
         $sql = 'select * from "metables" where "name" = ? or exists (select * from "meta_attributes" '.
-                'where "meta_attributes"."metable_id" = "metables"."id" and "meta_attributes"."metable_type" = ? '.
+                'where "metables"."id" = "meta_attributes"."metable_id" and "meta_attributes"."metable_type" = ? '.
                 'and "meta_key" = ? and "meta_value" = ?)';
 
         $query = $this->getModel()->where('name', 'jarek')->orWhere('color', 'red');
@@ -440,7 +440,7 @@ class MetableTest extends \PHPUnit_Framework_TestCase {
     public function meta_where_numeric()
     {
         $sql = 'select * from "metables" where exists (select * from "meta_attributes" '.
-                'where "meta_attributes"."metable_id" = "metables"."id" and "meta_attributes"."metable_type" = ? '.
+                'where "metables"."id" = "meta_attributes"."metable_id" and "meta_attributes"."metable_type" = ? '.
                 'and "meta_key" = ? and "meta_value" > 5)';
 
         $model = $this->getModel();
@@ -458,7 +458,7 @@ class MetableTest extends \PHPUnit_Framework_TestCase {
     public function meta_where()
     {
         $sql = 'select * from "metables" where exists (select * from "meta_attributes" '.
-                'where "meta_attributes"."metable_id" = "metables"."id" and "meta_attributes"."metable_type" = ? '.
+                'where "metables"."id" = "meta_attributes"."metable_id" and "meta_attributes"."metable_type" = ? '.
                 'and "meta_key" = ? and "meta_value" = ?)';
 
         $query = $this->getModel()->where('color', 'red');

--- a/tests/SearchableBuilderTest.php
+++ b/tests/SearchableBuilderTest.php
@@ -343,6 +343,7 @@ class SearchableBuilderTest extends \PHPUnit_Framework_TestCase {
         $schema->shouldReceive('getColumnListing')->andReturn(['id', 'first_name', 'last_name']);
         $connection = m::mock('Illuminate\Database\ConnectionInterface', ['getQueryGrammar' => $grammar, 'getPostProcessor' => $processor]);
         $connection->shouldReceive('getSchemaBuilder')->andReturn($schema);
+        $connection->shouldReceive('getName')->andReturn($driver);
         $resolver = m::mock('Illuminate\Database\ConnectionResolverInterface', ['connection' => $connection]);
         $class = get_class($model);
         $class::setConnectionResolver($resolver);


### PR DESCRIPTION
Hey @jarektkaczyk,

this is my first draft for #131. There are no tests yet. I would like to get your feedback first, if this is a way you would agree with.

## What does it do?
1. It adds a new column to the table `meta_group` which is a nullable `varchar`
2. when adding a meta item using the `setMeta` function the user can provide a third argument `$group`
3. If none is provided, it is just set to `NULL`
4. To get all attributes associated with a group simply use `getMetaByGroup('group-name')` on your model, which will return a `collection` of `Attributes`.

