### PR TITLE
Add composer scripts to easily test

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For older versions of Illuminate/Laravel please use:
 - 5.1.* -> [5.1](https://github.com/jarektkaczyk/eloquence/tree/5.1) branch.
 - 5.0.* -> [0.4](https://github.com/jarektkaczyk/eloquence/tree/0.4) branch.
 
-Currently available extensions: 
+Currently available extensions:
 
 1. `Searchable` query - crazy-simple fulltext search through any related model (based on https://github.com/nicolaslopezj/searchable only written from scratch & greatly improved)
 1. `Validable` - self-validating models
@@ -25,3 +25,8 @@ Currently available extensions:
 ## Contribution
 
 All contributions are welcome, PRs must be **tested** and **PSR-2 compliant**.
+
+To validate your builds before committing use the following composer command:
+```bash
+composer test
+```

--- a/composer.json
+++ b/composer.json
@@ -45,5 +45,9 @@
             "Sofa\\Eloquence\\Tests\\": "tests"
         }
     },
-    "minimum-stability": "stable"
+    "minimum-stability": "stable",
+    "scripts": {
+        "test": "phpunit && ./vendor/bin/phpcs src --standard=psr2 --report=diff --colors",
+        "phpcs": "./vendor/bin/phpcs src --standard=psr2 --report=diff --colors"
+    }
 }


### PR DESCRIPTION
This allows us to simply run:

```
composer test
```
to test phpunit and phpcs or run:
```
composer phpcs
```
to only test phpcs but with some helpful settings like color and diff.