### PR TITLE
Fix: Missing $args when calling next pipeline from replicate()

### DIFF
--- a/src/Metable/Hooks.php
+++ b/src/Metable/Hooks.php
@@ -76,7 +76,7 @@ class Hooks
 
             $copy->setRelation('metaAttributes', $metaAttributes);
 
-            return $next($copy);
+            return $next($copy, $args);
         };
     }
 


### PR DESCRIPTION
If replicate() has more than one hook - model updating fails with exception: $args will be null for next hook call, so PHP will try to call method "->get('original)" of non-object (this was found during a very long debugging session). 
Other method hooks in this class (like save()) plays well with the $args attribute, but replicate() do it wrong.