### PR TITLE
Use a minimal version instead of a fixed one

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
     ],
     "require": {
         "php": ">=5.6.4",
-        "sofa/hookable": "5.4.*",
-        "illuminate/database": "5.4.*"
+        "sofa/hookable": "^5.4",
+        "illuminate/database": "^5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0",


### PR DESCRIPTION
By using the ^ flag, you ask for a version that is superior to 5.4 but without breaking changes (so inferior to 6.0).