### PR TITLE
Fixed replicate() hook

### DIFF
--- a/src/Metable/Hooks.php
+++ b/src/Metable/Hooks.php
@@ -76,7 +76,7 @@ class Hooks
 
             $copy->setRelation('metaAttributes', $metaAttributes);
 
-            return $next($copy);
+            return $next($copy, $args);
         };
     }
 


### PR DESCRIPTION
replicate(): $args attribute was forgotten when calling next hook